### PR TITLE
chore: update shopify-dev local url

### DIFF
--- a/examples/remix-app/README.md
+++ b/examples/remix-app/README.md
@@ -47,7 +47,7 @@ To setup your discount function, you can use the Shopify CLI to create a new fun
 shopify app generate extension --template discount
 ```
 
-Then follow the instructions found in the [Build a discount UI with Remix](https://shopify-dev.myshopify.io/docs/apps/build/discounts/build-ui-with-remix?extension=rust#update-the-discount-function-extension-to-read-metafield-data) tutorial.
+Then follow the instructions found in the [Build a discount UI with Remix](https://shopify-dev.shop.dev/docs/apps/build/discounts/build-ui-with-remix?extension=rust#update-the-discount-function-extension-to-read-metafield-data) tutorial.
 
 ## Development
 


### PR DESCRIPTION
As per this [slack thread](https://shopify.slack.com/archives/C0Q0DSZR8/p1757956146871719) the local development url for shopify-dev is moving from `https://shopify-dev.myshopify.io/` to `https://shopify-dev.shop.dev/`

An example of error if not changed is [this thread](https://shopify.slack.com/archives/C01JS0YA85D/p1758556593647079)