### PR TITLE
DFT / Regenerate coderefs

### DIFF
--- a/examples/javascript/metafield/extensions/ui-extension/package.json
+++ b/examples/javascript/metafield/extensions/ui-extension/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "preact": "10.10.x",
     "@preact/signals": "2.3.x",
-    "@shopify/ui-extensions": "2025.10.0"
+    "@shopify/ui-extensions": "2026.01.0"
   }
 }

--- a/examples/javascript/metafield/extensions/ui-extension/src/DiscountFunctionSettings.jsx
+++ b/examples/javascript/metafield/extensions/ui-extension/src/DiscountFunctionSettings.jsx
@@ -113,12 +113,10 @@ function App() {
   const { discounts } = shopify;
   const discountClassesSignalValue = discounts?.discountClasses?.value ?? [];
 
-  const handleToggleDiscountClass = async (discountClasses) => {
-    const nextDiscountClasses = discountClassesSignalValue.includes(
-      discountClasses,
-    )
-      ? discountClassesSignalValue.filter((c) => c !== discountClasses)
-      : [...discountClassesSignalValue, discountClasses];
+  const handleToggleDiscountClass = async (nextValue) => {
+    const nextDiscountClasses = discountClassesSignalValue.includes(nextValue)
+      ? discountClassesSignalValue.filter((c) => c !== nextValue)
+      : [...discountClassesSignalValue, nextValue];
 
     const result =
       await discounts?.updateDiscountClasses?.(nextDiscountClasses);

--- a/examples/react-router-app/package.json
+++ b/examples/react-router-app/package.json
@@ -23,7 +23,7 @@
     "node": ">=20.10"
   },
   "dependencies": {
-    "@prisma/client": "6.16.3",
+    "@prisma/client": "6.18.0",
     "@react-router/dev": "7.9.3",
     "@react-router/fs-routes": "7.9.3",
     "@react-router/node": "7.9.3",
@@ -31,7 +31,7 @@
     "@shopify/app-bridge-react": "4.2.7",
     "@shopify/cli": "3.87.4",
     "@shopify/shopify-app-react-router": "1.0.2",
-    "@shopify/shopify-app-session-storage-prisma": "7.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "7.0.1",
     "isbot": "5.1.32",
     "prisma": "6.19.0",
     "react": "19.2.0",

--- a/examples/rust/metafield/extensions/ui-extension/package.json
+++ b/examples/rust/metafield/extensions/ui-extension/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "preact": "10.10.x",
     "@preact/signals": "2.3.x",
-    "@shopify/ui-extensions": "2025.10.0"
+    "@shopify/ui-extensions": "2026.01.0"
   }
 }

--- a/examples/rust/metafield/extensions/ui-extension/src/DiscountFunctionSettings.jsx
+++ b/examples/rust/metafield/extensions/ui-extension/src/DiscountFunctionSettings.jsx
@@ -113,12 +113,10 @@ function App() {
   const { discounts } = shopify;
   const discountClassesSignalValue = discounts?.discountClasses?.value ?? [];
 
-  const handleToggleDiscountClass = async (discountClasses) => {
-    const nextDiscountClasses = discountClassesSignalValue.includes(
-      discountClasses,
-    )
-      ? discountClassesSignalValue.filter((c) => c !== discountClasses)
-      : [...discountClassesSignalValue, discountClasses];
+  const handleToggleDiscountClass = async (nextValue) => {
+    const nextDiscountClasses = discountClassesSignalValue.includes(nextValue)
+      ? discountClassesSignalValue.filter((c) => c !== nextValue)
+      : [...discountClassesSignalValue, nextValue];
 
     const result =
       await discounts?.updateDiscountClasses?.(nextDiscountClasses);

--- a/package.json
+++ b/package.json
@@ -20,5 +20,14 @@
     "eslint-plugin-react-hooks": "7.0.1",
     "prettier": "3.6.2"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@9.15.9",
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,14 +20,5 @@
     "eslint-plugin-react-hooks": "7.0.1",
     "prettier": "3.6.2"
   },
-  "packageManager": "pnpm@9.15.9",
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --cache --fix",
-      "prettier --write"
-    ],
-    "*.{json,md,yml,yaml}": [
-      "prettier --write"
-    ]
-  }
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
- Update: "@shopify/ui-extensions": "~2026.01.0"
- Coderef update: rename the `handleToggleDiscountClass` callback's param to be `nextValue` instead of `discountClasses` as we're only getting the value of the current checkbox (single class, not plural)