### PR TITLE
Add shopify/Discount app intent link snippets for React Router tutorial

### DIFF
--- a/docs/reference/shopify/javascript/create-intent-schema.json
+++ b/docs/reference/shopify/javascript/create-intent-schema.json
@@ -6,8 +6,6 @@
     "additionalProperties": true,
     "properties": {
       "functionId": {
-        "type": "string",
-        "description": "The deployed Function ID for this metafield-configured discount function.",
         "matchValue": "YOUR_FUNCTION_ID"
       }
     }

--- a/docs/reference/shopify/javascript/create-intent-schema.json
+++ b/docs/reference/shopify/javascript/create-intent-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {
+      "functionId": {
+        "type": "string",
+        "description": "The deployed Function ID for this metafield-configured discount function.",
+        "matchValue": "YOUR_FUNCTION_ID"
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/docs/reference/shopify/javascript/edit-intent-schema.json
+++ b/docs/reference/shopify/javascript/edit-intent-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "value": {
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json",
+    "mapTo": "param",
+    "fieldName": "id"
+  },
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {
+      "functionId": {
+        "type": "string",
+        "description": "The deployed Function ID for this metafield-configured discount function.",
+        "matchValue": "YOUR_FUNCTION_ID"
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/docs/reference/shopify/javascript/edit-intent-schema.json
+++ b/docs/reference/shopify/javascript/edit-intent-schema.json
@@ -11,8 +11,6 @@
     "additionalProperties": true,
     "properties": {
       "functionId": {
-        "type": "string",
-        "description": "The deployed Function ID for this metafield-configured discount function.",
         "matchValue": "YOUR_FUNCTION_ID"
       }
     }

--- a/docs/reference/shopify/javascript/instructions.md
+++ b/docs/reference/shopify/javascript/instructions.md
@@ -1,0 +1,5 @@
+Use this app when the merchant wants to create or edit a metafield-configured discount powered by this app's Shopify Function.
+
+When invoking `create:shopify/Discount`, pass `functionId: "YOUR_FUNCTION_ID"` so Shopify resolves directly to this app's create flow.
+
+When invoking `edit:shopify/Discount`, pass the discount's GID (default to the canonical `gid://shopify/DiscountNode/{id}`) and `functionId: "YOUR_FUNCTION_ID"` so Shopify resolves the edit directly to this app.

--- a/docs/reference/shopify/javascript/shopify.extension.toml
+++ b/docs/reference/shopify/javascript/shopify.extension.toml
@@ -38,3 +38,42 @@ handle = "ui-multiclass-metafield-js"
 create = "/app/discount/:functionId/new"
 details = "/app/discount/:functionId/:id"
 # [END discount-function.ui-paths]
+
+# [START discount-function.app-intent-link]
+# Register app intent links so Sidekick can create and edit discounts backed by
+# this app's Function. Each admin.app.intent.link target maps a shopify/Discount
+# action (create or edit) to a page in your app.
+[[extensions]]
+name = "Create discount"
+description = "Create a metafield-configured discount powered by this app's Shopify Function."
+handle = "discount-app-intent-link-create"
+type = "admin_link"
+
+  [[extensions.targeting]]
+  target = "admin.app.intent.link"
+  # Hardcode your deployed Function's ID (see "Set your Function ID" below).
+  url = "/app/discount/YOUR_FUNCTION_ID/new"
+  instructions = "./instructions.md"
+
+  [[extensions.targeting.intents]]
+  type = "shopify/Discount"
+  action = "create"
+  schema = "./create-intent-schema.json"
+
+[[extensions]]
+name = "Edit discount"
+description = "Edit a metafield-configured discount powered by this app's Shopify Function."
+handle = "discount-app-intent-link-edit"
+type = "admin_link"
+
+  [[extensions.targeting]]
+  target = "admin.app.intent.link"
+  # The discount's GID fills {id}; the Function ID stays hardcoded.
+  url = "/app/discount/YOUR_FUNCTION_ID/{id}"
+  instructions = "./instructions.md"
+
+  [[extensions.targeting.intents]]
+  type = "shopify/Discount"
+  action = "edit"
+  schema = "./edit-intent-schema.json"
+# [END discount-function.app-intent-link]

--- a/docs/reference/shopify/javascript/shopify.extension.toml
+++ b/docs/reference/shopify/javascript/shopify.extension.toml
@@ -68,7 +68,7 @@ type = "admin_link"
 
   [[extensions.targeting]]
   target = "admin.app.intent.link"
-  # The discount's GID fills {id}; the Function ID stays hardcoded.
+  # {id} receives the discount ID; the Function ID stays hardcoded.
   url = "/app/discount/YOUR_FUNCTION_ID/{id}"
   instructions = "./instructions.md"
 

--- a/docs/reference/shopify/rust/create-intent-schema.json
+++ b/docs/reference/shopify/rust/create-intent-schema.json
@@ -6,8 +6,6 @@
     "additionalProperties": true,
     "properties": {
       "functionId": {
-        "type": "string",
-        "description": "The deployed Function ID for this metafield-configured discount function.",
         "matchValue": "YOUR_FUNCTION_ID"
       }
     }

--- a/docs/reference/shopify/rust/create-intent-schema.json
+++ b/docs/reference/shopify/rust/create-intent-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {
+      "functionId": {
+        "type": "string",
+        "description": "The deployed Function ID for this metafield-configured discount function.",
+        "matchValue": "YOUR_FUNCTION_ID"
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/docs/reference/shopify/rust/edit-intent-schema.json
+++ b/docs/reference/shopify/rust/edit-intent-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "value": {
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json",
+    "mapTo": "param",
+    "fieldName": "id"
+  },
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {
+      "functionId": {
+        "type": "string",
+        "description": "The deployed Function ID for this metafield-configured discount function.",
+        "matchValue": "YOUR_FUNCTION_ID"
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/docs/reference/shopify/rust/edit-intent-schema.json
+++ b/docs/reference/shopify/rust/edit-intent-schema.json
@@ -11,8 +11,6 @@
     "additionalProperties": true,
     "properties": {
       "functionId": {
-        "type": "string",
-        "description": "The deployed Function ID for this metafield-configured discount function.",
         "matchValue": "YOUR_FUNCTION_ID"
       }
     }

--- a/docs/reference/shopify/rust/instructions.md
+++ b/docs/reference/shopify/rust/instructions.md
@@ -1,0 +1,5 @@
+Use this app when the merchant wants to create or edit a metafield-configured discount powered by this app's Shopify Function.
+
+When invoking `create:shopify/Discount`, pass `functionId: "YOUR_FUNCTION_ID"` so Shopify resolves directly to this app's create flow.
+
+When invoking `edit:shopify/Discount`, pass the discount's GID (default to the canonical `gid://shopify/DiscountNode/{id}`) and `functionId: "YOUR_FUNCTION_ID"` so Shopify resolves the edit directly to this app.

--- a/docs/reference/shopify/rust/shopify.extension.toml
+++ b/docs/reference/shopify/rust/shopify.extension.toml
@@ -33,3 +33,42 @@ key = "function-configuration"
 create = "/app/discount/:functionId/new"
 details = "/app/discount/:functionId/:id"
 # [END discount-function.ui-paths]
+
+# [START discount-function.app-intent-link]
+# Register app intent links so Sidekick can create and edit discounts backed by
+# this app's Function. Each admin.app.intent.link target maps a shopify/Discount
+# action (create or edit) to a page in your app.
+[[extensions]]
+name = "Create discount"
+description = "Create a metafield-configured discount powered by this app's Shopify Function."
+handle = "discount-app-intent-link-create"
+type = "admin_link"
+
+  [[extensions.targeting]]
+  target = "admin.app.intent.link"
+  # Hardcode your deployed Function's ID (see "Set your Function ID" below).
+  url = "/app/discount/YOUR_FUNCTION_ID/new"
+  instructions = "./instructions.md"
+
+  [[extensions.targeting.intents]]
+  type = "shopify/Discount"
+  action = "create"
+  schema = "./create-intent-schema.json"
+
+[[extensions]]
+name = "Edit discount"
+description = "Edit a metafield-configured discount powered by this app's Shopify Function."
+handle = "discount-app-intent-link-edit"
+type = "admin_link"
+
+  [[extensions.targeting]]
+  target = "admin.app.intent.link"
+  # The discount's GID fills {id}; the Function ID stays hardcoded.
+  url = "/app/discount/YOUR_FUNCTION_ID/{id}"
+  instructions = "./instructions.md"
+
+  [[extensions.targeting.intents]]
+  type = "shopify/Discount"
+  action = "edit"
+  schema = "./edit-intent-schema.json"
+# [END discount-function.app-intent-link]

--- a/docs/reference/shopify/rust/shopify.extension.toml
+++ b/docs/reference/shopify/rust/shopify.extension.toml
@@ -63,7 +63,7 @@ type = "admin_link"
 
   [[extensions.targeting]]
   target = "admin.app.intent.link"
-  # The discount's GID fills {id}; the Function ID stays hardcoded.
+  # {id} receives the discount ID; the Function ID stays hardcoded.
   url = "/app/discount/YOUR_FUNCTION_ID/{id}"
   instructions = "./instructions.md"
 

--- a/examples/react-router-app/app/graphql/discounts.ts
+++ b/examples/react-router-app/app/graphql/discounts.ts
@@ -50,6 +50,9 @@ export const GET_DISCOUNT = `
 export const UPDATE_CODE_DISCOUNT = `
   mutation UpdateCodeDiscount($id: ID!, $discount: DiscountCodeAppInput!) {
     discountUpdate: discountCodeAppUpdate(id: $id, codeAppDiscount: $discount) {
+      codeAppDiscount {
+        discountId
+      }
       userErrors {
         code
         message
@@ -68,6 +71,9 @@ export const UPDATE_AUTOMATIC_DISCOUNT = `
       id: $id
       automaticAppDiscount: $discount
     ) {
+      automaticAppDiscount {
+        discountId
+      }
       userErrors {
         code
         message

--- a/examples/react-router-app/app/models/discounts.server.ts
+++ b/examples/react-router-app/app/models/discounts.server.ts
@@ -73,7 +73,8 @@ export async function createCodeDiscount(
 
   return {
     errors: responseJson.data.discountCreate?.userErrors as UserError[],
-    discount: responseJson.data.discountCreate?.codeAppDiscount,
+    discountId: responseJson.data.discountCreate?.codeAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -108,6 +109,8 @@ export async function createAutomaticDiscount(
 
   return {
     errors: responseJson.data.discountCreate?.userErrors as UserError[],
+    discountId: responseJson.data.discountCreate?.automaticAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -161,6 +164,8 @@ export async function updateCodeDiscount(
   const responseJson = await response.json();
   return {
     errors: responseJson.data.discountUpdate?.userErrors as UserError[],
+    discountId: responseJson.data.discountUpdate?.codeAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -207,6 +212,8 @@ export async function updateAutomaticDiscount(
   const responseJson = await response.json();
   return {
     errors: responseJson.data.discountUpdate?.userErrors as UserError[],
+    discountId: responseJson.data.discountUpdate?.automaticAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 

--- a/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
@@ -1,4 +1,5 @@
 import { Collection, DiscountClass } from "app/types/admin.types";
+import { useEffect, useRef } from "react";
 import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
@@ -16,6 +17,10 @@ import {
   updateCodeDiscount,
 } from "../models/discounts.server";
 import { DiscountMethod } from "../types/types";
+import {
+  completeDiscountWorkflow,
+  returnToDiscounts,
+} from "../utils/navigation";
 
 interface ActionData {
   errors?: {
@@ -24,6 +29,7 @@ interface ActionData {
     field?: string[];
   }[];
   success?: boolean;
+  discountId?: string;
 }
 
 interface LoaderData {
@@ -116,7 +122,10 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
   if (result.errors?.length > 0) {
     return { errors: result.errors };
   }
-  return { success: true };
+  if (!result.discountId) {
+    throw new Error("No discount ID returned");
+  }
+  return { success: true, discountId: result.discountId };
 };
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -148,6 +157,17 @@ export default function VolumeEdit() {
       ...error,
       field: error.field || [],
     })) || [];
+  const completedDiscountId = useRef<string | null>(null);
+
+  // [START build-the-ui.resolve-edit-intent]
+  useEffect(() => {
+    const discountId = actionData?.discountId;
+    if (!discountId || completedDiscountId.current === discountId) return;
+
+    completedDiscountId.current = discountId;
+    void completeDiscountWorkflow(discountId);
+  }, [actionData?.discountId]);
+  // [END build-the-ui.resolve-edit-intent]
 
   if (!rawDiscount) {
     return <NotFoundPage />;
@@ -178,15 +198,14 @@ export default function VolumeEdit() {
   };
 
   return (
-    <s-page heading={`Edit ${rawDiscount.title}`}>
-      <s-link
-        slot="breadcrumb-actions"
-        href="shopify://admin/discounts"
-        target="_top"
-      >
-        Discounts
-      </s-link>
-
+    <s-page
+      heading={`Edit ${rawDiscount.title}`}
+      breadcrumb-actions={
+        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
+          Discounts
+        </button>
+      }
+    >
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
@@ -198,14 +198,15 @@ export default function VolumeEdit() {
   };
 
   return (
-    <s-page
-      heading={`Edit ${rawDiscount.title}`}
-      breadcrumb-actions={
-        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
-          Discounts
-        </button>
-      }
-    >
+    <s-page heading={`Edit ${rawDiscount.title}`}>
+      <button
+        slot="breadcrumb-actions"
+        type="button"
+        variant="breadcrumb"
+        onClick={returnToDiscounts}
+      >
+        Discounts
+      </button>
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   type ActionFunctionArgs,
   useActionData,
@@ -11,7 +12,10 @@ import {
   createAutomaticDiscount,
 } from "../models/discounts.server";
 import { DiscountMethod } from "../types/types";
-import { returnToDiscounts } from "../utils/navigation";
+import {
+  completeDiscountWorkflow,
+  returnToDiscounts,
+} from "../utils/navigation";
 
 export const loader = async () => {
   // Initially load with empty collections since none are selected yet
@@ -76,7 +80,10 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
   if (result.errors?.length > 0) {
     return { errors: result.errors };
   }
-  return { success: true };
+  if (!result.discountId) {
+    throw new Error("No discount ID returned");
+  }
+  return { success: true, discountId: result.discountId };
 };
 // [END build-the-ui.add-action]
 
@@ -87,6 +94,7 @@ interface ActionData {
     field: string[];
   }[];
   success?: boolean;
+  discountId?: string;
 }
 
 interface LoaderData {
@@ -99,10 +107,17 @@ export default function VolumeNew() {
   const navigation = useNavigation();
   const isLoading = navigation.state === "submitting";
   const submitErrors = actionData?.errors || [];
+  const completedDiscountId = useRef<string | null>(null);
 
-  if (actionData?.success) {
-    returnToDiscounts();
-  }
+  // [START build-the-ui.resolve-create-intent]
+  useEffect(() => {
+    const discountId = actionData?.discountId;
+    if (!discountId || completedDiscountId.current === discountId) return;
+
+    completedDiscountId.current = discountId;
+    void completeDiscountWorkflow(discountId);
+  }, [actionData?.discountId]);
+  // [END build-the-ui.resolve-create-intent]
 
   const initialData = {
     title: "",

--- a/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
@@ -142,14 +142,15 @@ export default function VolumeNew() {
   };
 
   return (
-    <s-page
-      heading="Create product, order, and shipping discount"
-      breadcrumb-actions={
-        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
-          Discounts
-        </button>
-      }
-    >
+    <s-page heading="Create product, order, and shipping discount">
+      <button
+        slot="breadcrumb-actions"
+        type="button"
+        variant="breadcrumb"
+        onClick={returnToDiscounts}
+      >
+        Discounts
+      </button>
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/utils/navigation.ts
+++ b/examples/react-router-app/app/utils/navigation.ts
@@ -1,5 +1,29 @@
-export function returnToDiscounts() {
-  if (typeof window !== "undefined") {
-    window.open("shopify://admin/discounts", "_top");
+// [START build-the-ui.resolve-intent]
+export async function completeDiscountWorkflow(discountId: string) {
+  if (shopify.intents.request.value) {
+    await getIntentResponse().ok({ id: discountId });
+    return;
   }
+
+  openDiscountsPage();
+}
+
+export async function returnToDiscounts() {
+  if (shopify.intents.request.value) {
+    await getIntentResponse().closed();
+    return;
+  }
+
+  openDiscountsPage();
+}
+// [END build-the-ui.resolve-intent]
+
+function getIntentResponse() {
+  const response = shopify.intents.response;
+  if (!response) throw new Error("Intent response API unavailable");
+  return response;
+}
+
+function openDiscountsPage() {
+  window.open("shopify://admin/discounts", "_top");
 }

--- a/examples/react-router-app/package.json
+++ b/examples/react-router-app/package.json
@@ -28,7 +28,8 @@
     "@react-router/fs-routes": "7.9.3",
     "@react-router/node": "7.9.3",
     "@react-router/serve": "7.9.3",
-    "@shopify/app-bridge-react": "4.2.7",
+    "@shopify/app-bridge-react": "4.2.10",
+    "@shopify/app-bridge-types": "0.7.2",
     "@shopify/cli": "3.87.4",
     "@shopify/shopify-app-react-router": "1.0.2",
     "@shopify/shopify-app-session-storage-prisma": "7.0.1",
@@ -63,6 +64,11 @@
     "packages": [
       "extensions/*"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "@shopify/app-bridge-types": "0.7.2"
+    }
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"

--- a/examples/react-router-app/shopify.app.toml
+++ b/examples/react-router-app/shopify.app.toml
@@ -3,6 +3,12 @@
 # [START react-router-app.scopes]
 scopes = "write_discounts,read_products"
 # [END react-router-app.scopes]
+
+# [START react-router-app.sidekick-summary]
+[sidekick]
+extensions_summary = "Create and edit discounts powered by Shopify Functions"
+# [END react-router-app.sidekick-summary]
+
 [webhooks]
 api_version = "2024-10"
 

--- a/examples/react-router-app/tsconfig.json
+++ b/examples/react-router-app/tsconfig.json
@@ -23,7 +23,12 @@
     "moduleResolution": "Bundler",
     "target": "ES2022",
     "baseUrl": ".",
-    "types": ["@react-router/node", "vite/client", "@shopify/polaris-types"],
+    "types": [
+      "@react-router/node",
+      "vite/client",
+      "@shopify/app-bridge-types",
+      "@shopify/polaris-types"
+    ],
     "rootDirs": [".", "./.react-router/types"]
   }
 }


### PR DESCRIPTION
## Summary

Adds the coderef source snippets for the new **"Let Sidekick create and edit your discount"** step in the `build-ui-with-react-router` tutorial. Generated from Shopify/discount-functions-testing#1408 (`dev generate-reference-app`), scoped to only the app-intent-link files.

## Files
- `docs/reference/shopify/{javascript,rust}/shopify.extension.toml` — create + edit `admin.app.intent.link` extensions under the `discount-function.app-intent-link` tag (added to the existing React Router function toml)
- `docs/reference/shopify/{javascript,rust}/create-intent-schema.json`, `edit-intent-schema.json`, `instructions.md`

## Details
- create URL hardcodes `YOUR_FUNCTION_ID`; edit URL is `/app/discount/YOUR_FUNCTION_ID/{id}` (matches the app's `app.discount.$functionId.$id` route)
- `functionId` uses `matchValue`; no `tools.json`

## Related
- Source: Shopify/discount-functions-testing#1408
- Tutorial (coderefs): shop/world#919168

## Note on scope
This is a curated diff. A full `dev generate-reference-app` also rewrites ~110 unrelated files (oxfmt reflow, dependency/lockfile churn, new `.oxfmtrc.json`/`.oxlintrc.json`) because `main` is stale vs current `discount-functions-testing` main. That drift is intentionally omitted here and should be handled as a separate maintenance regen.