### PR TITLE
Resolve discount app intents after save or cancel

### DIFF
--- a/examples/react-router-app/app/graphql/discounts.ts
+++ b/examples/react-router-app/app/graphql/discounts.ts
@@ -50,6 +50,9 @@ export const GET_DISCOUNT = `
 export const UPDATE_CODE_DISCOUNT = `
   mutation UpdateCodeDiscount($id: ID!, $discount: DiscountCodeAppInput!) {
     discountUpdate: discountCodeAppUpdate(id: $id, codeAppDiscount: $discount) {
+      codeAppDiscount {
+        discountId
+      }
       userErrors {
         code
         message
@@ -68,6 +71,9 @@ export const UPDATE_AUTOMATIC_DISCOUNT = `
       id: $id
       automaticAppDiscount: $discount
     ) {
+      automaticAppDiscount {
+        discountId
+      }
       userErrors {
         code
         message

--- a/examples/react-router-app/app/models/discounts.server.ts
+++ b/examples/react-router-app/app/models/discounts.server.ts
@@ -73,7 +73,8 @@ export async function createCodeDiscount(
 
   return {
     errors: responseJson.data.discountCreate?.userErrors as UserError[],
-    discount: responseJson.data.discountCreate?.codeAppDiscount,
+    discountId: responseJson.data.discountCreate?.codeAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -108,6 +109,8 @@ export async function createAutomaticDiscount(
 
   return {
     errors: responseJson.data.discountCreate?.userErrors as UserError[],
+    discountId: responseJson.data.discountCreate?.automaticAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -161,6 +164,8 @@ export async function updateCodeDiscount(
   const responseJson = await response.json();
   return {
     errors: responseJson.data.discountUpdate?.userErrors as UserError[],
+    discountId: responseJson.data.discountUpdate?.codeAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 
@@ -207,6 +212,8 @@ export async function updateAutomaticDiscount(
   const responseJson = await response.json();
   return {
     errors: responseJson.data.discountUpdate?.userErrors as UserError[],
+    discountId: responseJson.data.discountUpdate?.automaticAppDiscount
+      ?.discountId as string | undefined,
   };
 }
 

--- a/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
@@ -1,4 +1,5 @@
 import { Collection, DiscountClass } from "app/types/admin.types";
+import { useEffect, useRef } from "react";
 import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
@@ -16,6 +17,10 @@ import {
   updateCodeDiscount,
 } from "../models/discounts.server";
 import { DiscountMethod } from "../types/types";
+import {
+  completeDiscountWorkflow,
+  returnToDiscounts,
+} from "../utils/navigation";
 
 interface ActionData {
   errors?: {
@@ -24,6 +29,7 @@ interface ActionData {
     field?: string[];
   }[];
   success?: boolean;
+  discountId?: string;
 }
 
 interface LoaderData {
@@ -116,7 +122,10 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
   if (result.errors?.length > 0) {
     return { errors: result.errors };
   }
-  return { success: true };
+  if (!result.discountId) {
+    throw new Error("No discount ID returned");
+  }
+  return { success: true, discountId: result.discountId };
 };
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -148,6 +157,17 @@ export default function VolumeEdit() {
       ...error,
       field: error.field || [],
     })) || [];
+  const completedDiscountId = useRef<string | null>(null);
+
+  // [START build-the-ui.resolve-edit-intent]
+  useEffect(() => {
+    const discountId = actionData?.discountId;
+    if (!discountId || completedDiscountId.current === discountId) return;
+
+    completedDiscountId.current = discountId;
+    void completeDiscountWorkflow(discountId);
+  }, [actionData?.discountId]);
+  // [END build-the-ui.resolve-edit-intent]
 
   if (!rawDiscount) {
     return <NotFoundPage />;
@@ -178,15 +198,14 @@ export default function VolumeEdit() {
   };
 
   return (
-    <s-page heading={`Edit ${rawDiscount.title}`}>
-      <s-link
-        slot="breadcrumb-actions"
-        href="shopify://admin/discounts"
-        target="_top"
-      >
-        Discounts
-      </s-link>
-
+    <s-page
+      heading={`Edit ${rawDiscount.title}`}
+      breadcrumb-actions={
+        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
+          Discounts
+        </button>
+      }
+    >
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.$id.tsx
@@ -198,14 +198,15 @@ export default function VolumeEdit() {
   };
 
   return (
-    <s-page
-      heading={`Edit ${rawDiscount.title}`}
-      breadcrumb-actions={
-        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
-          Discounts
-        </button>
-      }
-    >
+    <s-page heading={`Edit ${rawDiscount.title}`}>
+      <button
+        slot="breadcrumb-actions"
+        type="button"
+        variant="breadcrumb"
+        onClick={returnToDiscounts}
+      >
+        Discounts
+      </button>
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   type ActionFunctionArgs,
   useActionData,
@@ -11,7 +12,10 @@ import {
   createAutomaticDiscount,
 } from "../models/discounts.server";
 import { DiscountMethod } from "../types/types";
-import { returnToDiscounts } from "../utils/navigation";
+import {
+  completeDiscountWorkflow,
+  returnToDiscounts,
+} from "../utils/navigation";
 
 export const loader = async () => {
   // Initially load with empty collections since none are selected yet
@@ -76,7 +80,10 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
   if (result.errors?.length > 0) {
     return { errors: result.errors };
   }
-  return { success: true };
+  if (!result.discountId) {
+    throw new Error("No discount ID returned");
+  }
+  return { success: true, discountId: result.discountId };
 };
 // [END build-the-ui.add-action]
 
@@ -87,6 +94,7 @@ interface ActionData {
     field: string[];
   }[];
   success?: boolean;
+  discountId?: string;
 }
 
 interface LoaderData {
@@ -99,10 +107,17 @@ export default function VolumeNew() {
   const navigation = useNavigation();
   const isLoading = navigation.state === "submitting";
   const submitErrors = actionData?.errors || [];
+  const completedDiscountId = useRef<string | null>(null);
 
-  if (actionData?.success) {
-    returnToDiscounts();
-  }
+  // [START build-the-ui.resolve-create-intent]
+  useEffect(() => {
+    const discountId = actionData?.discountId;
+    if (!discountId || completedDiscountId.current === discountId) return;
+
+    completedDiscountId.current = discountId;
+    void completeDiscountWorkflow(discountId);
+  }, [actionData?.discountId]);
+  // [END build-the-ui.resolve-create-intent]
 
   const initialData = {
     title: "",

--- a/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
+++ b/examples/react-router-app/app/routes/app.discount.$functionId.new.tsx
@@ -142,14 +142,15 @@ export default function VolumeNew() {
   };
 
   return (
-    <s-page
-      heading="Create product, order, and shipping discount"
-      breadcrumb-actions={
-        <button type="button" variant="breadcrumb" onClick={returnToDiscounts}>
-          Discounts
-        </button>
-      }
-    >
+    <s-page heading="Create product, order, and shipping discount">
+      <button
+        slot="breadcrumb-actions"
+        type="button"
+        variant="breadcrumb"
+        onClick={returnToDiscounts}
+      >
+        Discounts
+      </button>
       <DiscountForm
         initialData={initialData}
         collections={collections}

--- a/examples/react-router-app/app/utils/navigation.ts
+++ b/examples/react-router-app/app/utils/navigation.ts
@@ -1,5 +1,29 @@
-export function returnToDiscounts() {
-  if (typeof window !== "undefined") {
-    window.open("shopify://admin/discounts", "_top");
+// [START build-the-ui.resolve-intent]
+export async function completeDiscountWorkflow(discountId: string) {
+  if (shopify.intents.request.value) {
+    await getIntentResponse().ok({ id: discountId });
+    return;
   }
+
+  openDiscountsPage();
+}
+
+export async function returnToDiscounts() {
+  if (shopify.intents.request.value) {
+    await getIntentResponse().closed();
+    return;
+  }
+
+  openDiscountsPage();
+}
+// [END build-the-ui.resolve-intent]
+
+function getIntentResponse() {
+  const response = shopify.intents.response;
+  if (!response) throw new Error("Intent response API unavailable");
+  return response;
+}
+
+function openDiscountsPage() {
+  window.open("shopify://admin/discounts", "_top");
 }

--- a/examples/react-router-app/package.json
+++ b/examples/react-router-app/package.json
@@ -28,7 +28,8 @@
     "@react-router/fs-routes": "7.9.3",
     "@react-router/node": "7.9.3",
     "@react-router/serve": "7.9.3",
-    "@shopify/app-bridge-react": "4.2.7",
+    "@shopify/app-bridge-react": "4.2.10",
+    "@shopify/app-bridge-types": "0.7.2",
     "@shopify/cli": "3.87.4",
     "@shopify/shopify-app-react-router": "1.0.2",
     "@shopify/shopify-app-session-storage-prisma": "7.0.1",
@@ -63,6 +64,11 @@
     "packages": [
       "extensions/*"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "@shopify/app-bridge-types": "0.7.2"
+    }
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"

--- a/examples/react-router-app/shopify.app.toml
+++ b/examples/react-router-app/shopify.app.toml
@@ -3,6 +3,12 @@
 # [START react-router-app.scopes]
 scopes = "write_discounts,read_products"
 # [END react-router-app.scopes]
+
+# [START react-router-app.sidekick-summary]
+[sidekick]
+extensions_summary = "Create and edit discounts powered by Shopify Functions"
+# [END react-router-app.sidekick-summary]
+
 [webhooks]
 api_version = "2024-10"
 

--- a/examples/react-router-app/tsconfig.json
+++ b/examples/react-router-app/tsconfig.json
@@ -23,7 +23,12 @@
     "moduleResolution": "Bundler",
     "target": "ES2022",
     "baseUrl": ".",
-    "types": ["@react-router/node", "vite/client", "@shopify/polaris-types"],
+    "types": [
+      "@react-router/node",
+      "vite/client",
+      "@shopify/app-bridge-types",
+      "@shopify/polaris-types"
+    ],
     "rootDirs": [".", "./.react-router/types"]
   }
 }


### PR DESCRIPTION
## Why

Follow-up to #75. The registered React Router discount intent links currently save or navigate without resolving the intent, leaving Sidekick or another invoker waiting for the declared output.

## What changed

- return the authoritative `discountId` from create and update mutations
- resolve successful intent saves with `shopify.intents.response.ok({id})`
- resolve intent cancellation with `shopify.intents.response.closed()`
- preserve existing navigation when the page was not opened as an intent
- upgrade App Bridge types so the request and response APIs are typed
- add source tags for the associated shopify.dev tutorial

## Validation

- `pnpm exec tsc --noEmit`
- targeted ESLint
- targeted Prettier
- `env -u HOST -u SHOPIFY_APP_URL pnpm run build`
- `git diff --check`

Dependency for shop/world#919168.